### PR TITLE
Add support for predefined constants in crontab files

### DIFF
--- a/grammars/crontab.cson
+++ b/grammars/crontab.cson
@@ -23,11 +23,20 @@
         'name': 'string.command.crontab'
   }
   {
+    'match': '^\\s*(@yearly|@annually|@monthly|@weekly|@daily|@hourly|@reboot)\\s+(.*)$'
+    'name': 'statement.crontab'
+    'captures':
+      '1':
+        'name': 'meta.constant.crontab'
+      '2':
+        'name': 'string.command.crontab'
+  }
+  {
     'match': '^#.*$'
     'name': 'comment.crontab'
   }
   {
-    'match': "^\\s*(HOME|SHELL|MAILFROM|MAILTO|CRON_TZ)\\s*(=)\\s*(.*)$"
+    'match': "^\\s*([a-zA-Z0-9_]+)\\s*(=)\\s*(.*)$"
     'name': 'environment.crontab'
     'captures':
       '1':

--- a/styles/language-cron.less
+++ b/styles/language-cron.less
@@ -1,6 +1,6 @@
 // The ui-variables file is provided by base themes provided by Atom.
 //
-// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
+// See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
 
@@ -21,6 +21,9 @@ atom-text-editor::shadow {
       }
       &.dayofweek {
         color: @ui-site-color-4;
+      }
+      &.constant {
+        color: @ui-site-color-5;
       }
     }
   }


### PR DESCRIPTION
See `Nonstandard predefined scheduling definitions` in http://en.wikipedia.org/wiki/Cron

Also support all type of env vars in crontab files.
